### PR TITLE
chore(code): Add .prettierignore

### DIFF
--- a/client/.prettierignore
+++ b/client/.prettierignore
@@ -1,0 +1,2 @@
+
+pnpm-*.yaml

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "lint-staged": {
     "client/src/**/*.{ts,tsx,js,jsx}": [
       "pnpm eslint -c ./client/eslint.config.js --fix client",
-      "pnpm prettier --config .prettierrc --write client"
+      "pnpm prettier --config .prettierrc --write --ignore-path ./client/.prettierignore client"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## What's Changed:
- Adding a `.prettierignore` file, which Includes `pnpm-*.yaml` files, which are automatically formatted by prettier, which I do not want.