### PR TITLE
feat: Add Page for Note which shows all the info about the Note

### DIFF
--- a/client/src/components/ui/Note/Note.tsx
+++ b/client/src/components/ui/Note/Note.tsx
@@ -4,11 +4,17 @@ import { Divider } from "@heroui/react";
 
 import { Note as NoteProps } from "@/types";
 
+/**
+ * The Note preview component for displaying a note in a note grid.
+ *
+ * @component
+ */
 export const Note = ({ id, title, notes: content }: NoteProps) => (
-  <div className="bg-default-200/50 hover:bg-default-200/75 inline-block cursor-pointer rounded-lg py-4">
+  <div className="bg-default-200/50 hover:bg-default-200/75 relative inline-block cursor-pointer rounded-lg py-4">
     {/* Card Header */}
     <div className="flex items-center px-4">
       <Link to={`/note/${id}`}>
+        <span className="absolute inset-0"></span>
         <h1 className="text-default-800 line-clamp-1 text-ellipsis text-lg font-semibold">
           {title}
         </h1>

--- a/client/src/components/ui/NoteGrid/NoteGrid.tsx
+++ b/client/src/components/ui/NoteGrid/NoteGrid.tsx
@@ -4,7 +4,7 @@ import { Each } from "@/components/utils";
 import { NoteGridProps } from "./NoteGrid.types";
 
 export const NoteGrid = ({ notes, endChild }: NoteGridProps) => (
-  <div className="grid grid-cols-3 items-stretch gap-x-4 gap-y-6">
+  <div className="grid grid-cols-1 items-stretch gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-3">
     <Each of={notes} render={(note) => <Note key={note.id} {...note} />} />
     {endChild}
   </div>

--- a/client/src/pages/NewNote/NewNote.tsx
+++ b/client/src/pages/NewNote/NewNote.tsx
@@ -65,10 +65,10 @@ export const NewNotePage = () => {
                   required: "This field is required",
                 })}
                 placeholder="Title goes here"
-                className="hover:bg-default-100 active:bg-default-100 focus:bg-default-100 text-default-900 w-full rounded-r-md border-l bg-transparent px-4 py-2 text-4xl font-black leading-6 outline-none lg:text-6xl"
                 aria-required="true"
                 aria-invalid={!!errors.title}
                 aria-describedby="new-note-title-error"
+                className="hover:bg-default-100 active:bg-default-100 focus:bg-default-100 text-default-900 border-default-400 w-full rounded-r-md border-l-2 bg-transparent px-4 py-2 text-4xl font-black leading-6 outline-none lg:text-6xl"
               />
               {errors.title && (
                 <p
@@ -91,7 +91,7 @@ export const NewNotePage = () => {
                 disabled={isSubmitting}
                 placeholder="We support markdown"
                 rows={10}
-                className="hover:bg-default-100 focus:bg-default-100 w-full resize-none rounded-md bg-transparent p-4 font-mono text-lg outline-none"
+                className="hover:bg-default-100 text-default-600 focus:bg-default-100 w-full resize-none rounded-md bg-transparent p-4 font-mono text-lg outline-none"
               />
             </div>
 

--- a/client/src/pages/Note/Note.tsx
+++ b/client/src/pages/Note/Note.tsx
@@ -1,0 +1,34 @@
+import { useParams } from "react-router-dom";
+
+import { Note } from "@/types";
+import { loadFromStorage } from "@/utils";
+
+export const NotePage = () => {
+  const { id } = useParams();
+  const notes = loadFromStorage<Note[]>("notes", []);
+
+  if (!notes) return <div>Loading...</div>;
+  const note = notes?.find((note) => note.id === id);
+  if (!note) return <div>Note not found</div>;
+
+  return (
+    <div className="max-w-app mx-auto pt-5">
+      <div className="px-2">
+        <h1 className="text-center text-3xl font-semibold">Note App</h1>
+        <div className="mt-10 flex flex-col gap-4">
+          <div className="my-8">
+            <h1 className="hover:bg-default-100 active:bg-default-100 focus:bg-default-100 text-default-900 border-default-400 w-full rounded-r-md border-l-2 bg-transparent px-4 py-2 text-4xl font-black leading-loose outline-none lg:text-6xl lg:leading-normal">
+              {note?.title}
+            </h1>
+          </div>
+
+          <div className="mb-8">
+            <article className="text-default-600 w-full resize-none bg-transparent p-4 text-xl leading-8 tracking-wide outline-none">
+              {note.notes}
+            </article>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/client/src/pages/Note/index.ts
+++ b/client/src/pages/Note/index.ts
@@ -1,0 +1,1 @@
+export { NotePage } from "./Note";

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -2,3 +2,4 @@ export { HomePage } from "./Home";
 export { LoginPage } from "./Login";
 export { SignupPage } from "./Signup";
 export { NewNotePage } from "./NewNote";
+export { NotePage } from "./Note";

--- a/client/src/routes/router.tsx
+++ b/client/src/routes/router.tsx
@@ -2,10 +2,17 @@ import { createBrowserRouter } from "react-router-dom";
 
 import { withProtected, withRestrictedPublic } from "@/components/auth";
 import { DefaultLayout } from "@/layouts";
-import { HomePage, LoginPage, NewNotePage, SignupPage } from "@/pages";
+import {
+  HomePage,
+  LoginPage,
+  NewNotePage,
+  NotePage,
+  SignupPage,
+} from "@/pages";
 
 const Home = withProtected(HomePage);
 const NewNote = withProtected(NewNotePage);
+const Note = withProtected(NotePage);
 const Login = withRestrictedPublic(LoginPage);
 const Signup = withRestrictedPublic(SignupPage);
 
@@ -33,6 +40,11 @@ export const router = createBrowserRouter([
             /* route: /note/new */
             path: "new",
             element: <NewNote />,
+          },
+          {
+            /* route: /note/:id */
+            path: ":id",
+            element: <Note />,
           },
         ],
       },

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -8,6 +8,13 @@ export default {
     "./node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
+    screens: {
+      sm: "640px",
+      md: "768px",
+      lg: "1024px",
+      xl: "1440px",
+      "2xl": "1920px",
+    },
     extend: {
       maxWidth: {
         app: "1024px",


### PR DESCRIPTION
## What's changed:
- Add Note Page for Notes with route `/note/:id`
- Improve styles for Note preview component, New Note Page