### PR TITLE
Fix Husky Setup Error

### DIFF
--- a/client/.prettierignore
+++ b/client/.prettierignore
@@ -1,2 +1,5 @@
 
+dist/
+coverage/
+
 pnpm-*.yaml

--- a/package.json
+++ b/package.json
@@ -1,4 +1,10 @@
 {
+  "scripts": {
+    "format": "pnpm prettier --config .prettierrc --write --ignore-path ./client/.prettierignore client",
+    "format:checkonly": "pnpm prettier --config .prettierrc --check --ignore-path ./client/.prettierignore client",
+    "lint": "pnpm eslint -c ./client/eslint.config.js --fix client",
+    "lint:checkonly": "pnpm eslint -c ./client/eslint.config.js client"
+  },
   "packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971",
   "devDependencies": {
     "@eslint/js": "^9.25.1",
@@ -11,8 +17,8 @@
   },
   "lint-staged": {
     "client/src/**/*.{ts,tsx,js,jsx}": [
-      "pnpm eslint -c ./client/eslint.config.js --fix client",
-      "pnpm prettier --config .prettierrc --write --ignore-path ./client/.prettierignore client"
+      "pnpm lint:checkonly",
+      "pnpm format:checkonly"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## Description:
- Check if the code is **linted** & **formatted** rather than linting and formatting
- Using prettier and eslint to only check for linting and formatting, so that `lint-staged` doesn't lint and format, but only check if the code is correctly formatted and linted. This helps in throwing an error from the prettier and eslint and the commit can be stopped due to lint-staged error.
