### PR TITLE
fix(auth): Fix duplicate signup bug

### DIFF
--- a/client/src/containers/SignupContainer/Signup.container.tsx
+++ b/client/src/containers/SignupContainer/Signup.container.tsx
@@ -55,9 +55,11 @@ export const SignupContainer = () => {
     });
 
     if (error) {
-      setError("root", {
-        message: error.message,
-      });
+      if (error.status === 422)
+        setError("email", {
+          message: "An account already exists with this email!!",
+        });
+      else setError("root", { message: error.message });
     }
   };
 
@@ -139,6 +141,11 @@ export const SignupContainer = () => {
         >
           Sign Up
         </Button>
+        {errors.root && (
+          <p className="text-small text-danger-500 text-center">
+            {errors.root.message}
+          </p>
+        )}
       </form>
       <p className="text-small text-default-800 text-center hover:underline">
         <Link to={ROUTES.LOGIN_ROUTE}>Already have an account? Log In</Link>


### PR DESCRIPTION
# 🐞 Bug Fix

## Description
The signup functionality doesn't throw any error on creating a new account with an existing email. This PR resolves this issue by enforcing the `supabase` to check for the error before signing up and throw an error.


## Checklist

- [X] The fix does not introduce regressions
- [X] I’ve verified the fix in the affected environment(s)

## Screenshots
![image](https://github.com/user-attachments/assets/b0207250-35d1-479d-9791-403da94fad9b)

