### PR TITLE
fix: Fix unmatched sonner theme with the app theme

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 
+import { Toaster } from "sonner";
+
 import { THEME } from "@/constants";
 import { selectTheme } from "@/features";
 import { useAppSelector } from "@/hooks";
@@ -22,7 +24,21 @@ const App = () => {
     document.body.classList.toggle("dark", theme === THEME.DARK);
   }, [theme]);
 
-  return <RouterProvider router={router} />;
+  return (
+    <>
+      <Toaster
+        richColors
+        closeButton
+        position="top-right"
+        offset={{
+          top: 60,
+          right: 20,
+        }}
+        theme={theme === THEME.LIGHT ? "light" : "dark"}
+      />
+      <RouterProvider router={router} />
+    </>
+  );
 };
 
 export default App;

--- a/client/src/Provider.tsx
+++ b/client/src/Provider.tsx
@@ -1,23 +1,12 @@
 import { ReactNode } from "react";
 import { Provider as StoreProvider } from "react-redux";
 
-import { Toaster } from "sonner";
 import { HeroUIProvider } from "@heroui/system";
 
 import { store } from "@/store";
 
 const Provider = ({ children }: { children: ReactNode }) => (
   <HeroUIProvider>
-    <Toaster
-      richColors
-      closeButton
-      position="top-right"
-      offset={{
-        top: 60,
-        right: 20,
-      }}
-      theme="system"
-    />
     <StoreProvider store={store}>{children}</StoreProvider>
   </HeroUIProvider>
 );


### PR DESCRIPTION
# 🐞 Bug Fix

## Description
The `sonner` toasts theme is not in sync with the application base theme. It is set to the `system` value, which defaults to the current **OS theme**, which is not looking really good if the OS theme and app theme are quite opposite. So force sync the `sonner` theme with the application theme.

## Checklist

- [ ] I have added tests to prevent this issue from reoccurring
- [X] The fix does not introduce regressions
- [X] I’ve verified the fix in the affected environment(s)
